### PR TITLE
Add support to add to publish towards jQuery plugins repo

### DIFF
--- a/payment.jquery.json
+++ b/payment.jquery.json
@@ -3,7 +3,7 @@
     "title": "jQuery Payment",
     "description": "A general purpose library for building credit card forms, validating inputs and formatting numbers.",
     "keywords": [
-        "credit cards",
+        "credit-cards",
         "payments"
     ],
     "version": "1.0.0",


### PR DESCRIPTION
Please review the manifest file for any additions.

Next, set up a post-receive hook to the following URL:
http://plugins.jquery.com/postreceive-hook

Finally, tag your final commit v1.0.0 (or 1.0.0) and push tag + changes back up to github. The postreceive will publish to plugins.jquery.com

All future releases should follow semver standards, in that patch releases increment x.x.X, minor releases increment x.X.- and reset the patch version, and major releases increment X.-.- and reset all integers afterwords. Special releases should be suffixed with x.x.x-special.tag. As a matter of consideration, breaking changes should be reserved for minor releases only, leaving patch releases stable to it's current tree.

Cheers!
