### PR TITLE
Fix bug trapping keyboard shortcuts on FF/Win

### DIFF
--- a/lib/jquery.payment.js
+++ b/lib/jquery.payment.js
@@ -262,7 +262,7 @@
 
   restrictNumeric = function(e) {
     var char;
-    if (e.metaKey) {
+    if (e.metaKey || e.ctrlKey) {
       return true;
     }
     if (e.which === 32) {

--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -235,7 +235,7 @@ formatBackExpiry = (e) ->
 
 restrictNumeric = (e) ->
   # Key event is for a browser shortcut
-  return true if e.metaKey
+  return true if e.metaKey or e.ctrlKey
 
   # If keycode is a space
   return false if e.which is 32


### PR DESCRIPTION
The `restrictNumeric` method checks whether the `metaKey` is pressed, but also
needs to check `ctrlKey` for Windows users, so that <kbd>Ctrl</kbd>+<kbd>T</kbd> (new tab) and 
similar shortcuts aren't trapped and cancelled.

Fixes #28 
