### PR TITLE
use isNaN and parseInt for fasterness

### DIFF
--- a/lib/jquery.payment.js
+++ b/lib/jquery.payment.js
@@ -151,7 +151,7 @@
   formatCardNumber = function(e) {
     var $target, card, digit, length, re, upperLength, value;
     digit = String.fromCharCode(e.which);
-    if (!/^\d+$/.test(digit)) {
+    if (isNaN(parseInt(digit, 10))) {
       return;
     }
     $target = $(e.currentTarget);
@@ -201,12 +201,12 @@
   formatExpiry = function(e) {
     var $target, digit, val;
     digit = String.fromCharCode(e.which);
-    if (!/^\d+$/.test(digit)) {
+    if (isNaN(parseInt(digit, 10))) {
       return;
     }
     $target = $(e.currentTarget);
     val = $target.val() + digit;
-    if (/^\d$/.test(val) && (val !== '0' && val !== '1')) {
+    if (!isNaN(parseInt(digit, 10)) && (val !== '0' && val !== '1')) {
       e.preventDefault();
       return $target.val("0" + val + " / ");
     } else if (/^\d\d$/.test(val)) {
@@ -218,7 +218,7 @@
   formatForwardExpiry = function(e) {
     var $target, digit, val;
     digit = String.fromCharCode(e.which);
-    if (!/^\d+$/.test(digit)) {
+    if (isNaN(parseInt(digit, 10))) {
       return;
     }
     $target = $(e.currentTarget);
@@ -236,7 +236,7 @@
     }
     $target = $(e.currentTarget);
     val = $target.val();
-    if (/^\d$/.test(val) && val !== '0') {
+    if (!isNaN(parseInt(val, 10)) && val !== '0') {
       return $target.val("0" + val + " / ");
     }
   };
@@ -282,7 +282,7 @@
     var $target, card, digit, value;
     $target = $(e.currentTarget);
     digit = String.fromCharCode(e.which);
-    if (!/^\d+$/.test(digit)) {
+    if (isNaN(parseInt(digit, 10))) {
       return;
     }
     if (hasTextSelected($target)) {
@@ -301,7 +301,7 @@
     var $target, digit, value;
     $target = $(e.currentTarget);
     digit = String.fromCharCode(e.which);
-    if (!/^\d+$/.test(digit)) {
+    if (isNaN(parseInt(digit, 10))) {
       return;
     }
     if (hasTextSelected($target)) {
@@ -318,7 +318,7 @@
     var $target, digit, val;
     $target = $(e.currentTarget);
     digit = String.fromCharCode(e.which);
-    if (!/^\d+$/.test(digit)) {
+    if (isNaN(parseInt(digit, 10))) {
       return;
     }
     val = $target.val() + digit;
@@ -387,7 +387,7 @@
     var month, prefix, year, _ref;
     value = value.replace(/\s/g, '');
     _ref = value.split('/', 2), month = _ref[0], year = _ref[1];
-    if ((year != null ? year.length : void 0) === 2 && /^\d+$/.test(year)) {
+    if ((year != null ? year.length : void 0) === 2 && !isNaN(parseInt(year, 10))) {
       prefix = (new Date).getFullYear();
       prefix = prefix.toString().slice(0, 2);
       year = prefix + year;
@@ -403,7 +403,7 @@
   $.payment.validateCardNumber = function(num) {
     var card, _ref;
     num = (num + '').replace(/\s+|-/g, '');
-    if (!/^\d+$/.test(num)) {
+    if (isNaN(parseInt(num, 10))) {
       return false;
     }
     card = cardFromNumber(num);
@@ -423,10 +423,10 @@
     }
     month = $.trim(month);
     year = $.trim(year);
-    if (!/^\d+$/.test(month)) {
+    if (isNaN(parseInt(month, 10))) {
       return false;
     }
-    if (!/^\d+$/.test(year)) {
+    if (isNaN(parseInt(year, 10))) {
       return false;
     }
     if (!(parseInt(month, 10) <= 12)) {
@@ -442,7 +442,7 @@
   $.payment.validateCardCVC = function(cvc, type) {
     var _ref, _ref1;
     cvc = $.trim(cvc);
-    if (!/^\d+$/.test(cvc)) {
+    if (isNaN(parseInt(cvc, 10))) {
       return false;
     }
     if (type) {

--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -128,7 +128,7 @@ reFormatCardNumber = (e) ->
 formatCardNumber = (e) ->
   # Only format if input is a number
   digit = String.fromCharCode(e.which)
-  return unless /^\d+$/.test(digit)
+  return if isNaN parseInt(digit,10)
 
   $target = $(e.currentTarget)
   value   = $target.val()
@@ -179,12 +179,12 @@ formatBackCardNumber = (e) ->
 formatExpiry = (e) ->
   # Only format if input is a number
   digit = String.fromCharCode(e.which)
-  return unless /^\d+$/.test(digit)
+  return if isNaN parseInt(digit, 10)
 
   $target = $(e.currentTarget)
   val     = $target.val() + digit
 
-  if /^\d$/.test(val) and val not in ['0', '1']
+  if !isNaN(parseInt(digit, 10)) and val not in ['0', '1']
     e.preventDefault()
     $target.val("0#{val} / ")
 
@@ -194,7 +194,7 @@ formatExpiry = (e) ->
 
 formatForwardExpiry = (e) ->
   digit = String.fromCharCode(e.which)
-  return unless /^\d+$/.test(digit)
+  return if isNaN parseInt(digit, 10)
 
   $target = $(e.currentTarget)
   val     = $target.val()
@@ -209,7 +209,7 @@ formatForwardSlash = (e) ->
   $target = $(e.currentTarget)
   val     = $target.val()
 
-  if /^\d$/.test(val) and val isnt '0'
+  if !isNaN(parseInt(val, 10)) and val isnt '0'
     $target.val("0#{val} / ")
 
 formatBackExpiry = (e) ->
@@ -254,7 +254,7 @@ restrictNumeric = (e) ->
 restrictCardNumber = (e) ->
   $target = $(e.currentTarget)
   digit   = String.fromCharCode(e.which)
-  return unless /^\d+$/.test(digit)
+  return if isNaN parseInt(digit, 10)
 
   return if hasTextSelected($target)
 
@@ -271,7 +271,7 @@ restrictCardNumber = (e) ->
 restrictExpiry = (e) ->
   $target = $(e.currentTarget)
   digit   = String.fromCharCode(e.which)
-  return unless /^\d+$/.test(digit)
+  return if isNaN parseInt(digit, 10)
 
   return if hasTextSelected($target)
 
@@ -283,7 +283,8 @@ restrictExpiry = (e) ->
 restrictCVC = (e) ->
   $target = $(e.currentTarget)
   digit   = String.fromCharCode(e.which)
-  return unless /^\d+$/.test(digit)
+  return if isNaN parseInt(digit, 10)
+
 
   val     = $target.val() + digit
   val.length <= 4
@@ -346,7 +347,7 @@ $.payment.cardExpiryVal = (value) ->
   [month, year] = value.split('/', 2)
 
   # Allow for year shortcut
-  if year?.length is 2 and /^\d+$/.test(year)
+  if year?.length is 2 and !isNaN parseInt(year, 10)
     prefix = (new Date).getFullYear()
     prefix = prefix.toString()[0..1]
     year   = prefix + year
@@ -358,7 +359,7 @@ $.payment.cardExpiryVal = (value) ->
 
 $.payment.validateCardNumber = (num) ->
   num = (num + '').replace(/\s+|-/g, '')
-  return false unless /^\d+$/.test(num)
+  return false if isNaN parseInt(num, 10)
 
   card = cardFromNumber(num)
   return false unless card
@@ -376,8 +377,8 @@ $.payment.validateCardExpiry = (month, year) =>
   month = $.trim(month)
   year  = $.trim(year)
 
-  return false unless /^\d+$/.test(month)
-  return false unless /^\d+$/.test(year)
+  return false if isNaN parseInt(month, 10)
+  return false if isNaN parseInt(year, 10)
   return false unless parseInt(month, 10) <= 12
 
   expiry      = new Date(year, month)
@@ -395,7 +396,7 @@ $.payment.validateCardExpiry = (month, year) =>
 
 $.payment.validateCardCVC = (cvc, type) ->
   cvc = $.trim(cvc)
-  return false unless /^\d+$/.test(cvc)
+  return false if isNaN parseInt(cvc, 10)
 
   if type
     # Check against a explicit card type


### PR DESCRIPTION
Using `isNaN(parseInt(digit, 10))` is faster than `unless /^\d+$/.test(digit)` (see [jsperf](http://jsperf.com/test-if-number-2)), and I think reads a little cleaner, since a lot of the surrounding code is using parseInt anyways. The unary operator (`+digit`), which is essentially a shorthand for `Number(digit)`, looks even cleaner but is slightly slower. 
