### PR TITLE
YUI JS Compressor breaks on variable name "char"

### DIFF
--- a/lib/jquery.payment.js
+++ b/lib/jquery.payment.js
@@ -261,7 +261,7 @@
   };
 
   restrictNumeric = function(e) {
-    var char;
+    var theChar;
     if (e.metaKey || e.ctrlKey) {
       return true;
     }
@@ -274,8 +274,8 @@
     if (e.which < 33) {
       return true;
     }
-    char = String.fromCharCode(e.which);
-    return !!/[\d\s]/.test(char);
+    theChar = String.fromCharCode(e.which);
+    return !!/[\d\s]/.test(theChar);
   };
 
   restrictCardNumber = function(e) {


### PR DESCRIPTION
Changed variable name to theChar so it would minify nicely.
