### PR TITLE
Conciseness nitpick.

### DIFF
--- a/lib/jquery.payment.js
+++ b/lib/jquery.payment.js
@@ -158,10 +158,7 @@
     value = $target.val();
     card = cardFromNumber(value + digit);
     length = (value.replace(/\D/g, '') + digit).length;
-    upperLength = 16;
-    if (card) {
-      upperLength = card.length[card.length.length - 1];
-    }
+    upperLength = card ? card.length[card.length.length - 1] : 16;
     if (length >= upperLength) {
       return;
     }

--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -135,8 +135,7 @@ formatCardNumber = (e) ->
   card    = cardFromNumber(value + digit)
   length  = (value.replace(/\D/g, '') + digit).length
 
-  upperLength = 16
-  upperLength = card.length[card.length.length - 1] if card
+  upperLength = if card then card.length[card.length.length - 1] else 16
   return if length >= upperLength
 
   # Return if focus isn't at the end of the text


### PR DESCRIPTION
Instead of setting the upperLength variable twice, just set it once.

I really wish CoffeeScript accepted `var = value1 IF condition ELSE value2`, But alas, it does not.
