### PR TITLE
$.payment.validateCardExpiry(month, year) now supports year shorthand as advertised

### DIFF
--- a/lib/jquery.payment.js
+++ b/lib/jquery.payment.js
@@ -432,6 +432,9 @@
     if (!(parseInt(month, 10) <= 12)) {
       return false;
     }
+    if (year.length !== 4) {
+      year = "20" + year;
+    }
     expiry = new Date(year, month);
     currentTime = new Date;
     expiry.setMonth(expiry.getMonth() - 1);

--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -380,6 +380,8 @@ $.payment.validateCardExpiry = (month, year) =>
   return false unless /^\d+$/.test(year)
   return false unless parseInt(month, 10) <= 12
 
+  year = "20#{year}" unless year.length is 4
+
   expiry      = new Date(year, month)
   currentTime = new Date
 

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -136,6 +136,11 @@ describe 'jquery.payment', ->
       topic = $.payment.validateCardExpiry '12', NaN
       assert.equal topic, false
 
+    it 'should support year shorthand', ->
+      month = '05'
+      year = '20'
+      assert.equal $.payment.validateCardExpiry(month, year), true
+
   describe 'Parsing an expiry value', ->
     it 'should parse string expiry', ->
       topic = $.payment.cardExpiryVal('03 / 2025')


### PR DESCRIPTION
### $.payment.validateCardExpiry(month, year) correct year shorthand support
- `$.payment.validateCardExpiry(month, year)` does not correctly support year shorthand in its current state. 
- The reason for this is that the JavaScript `Date` class appends <strong>19</strong>, <em>not</em> <strong>20</strong> as the numerical prefix for the `year` argument supplied to the constructor i.e. `var d = new Date(year, month, day, hours, minutes, seconds, milliseconds);`

This pull request includes the following:
- A test, initially failing, then made to pass, which asserts that `$.payment.validateCardExpiry('05', '20') == true`
- An additional line added to the function definition for `$.payment.validateCardExpiry(month, year)` which uses CoffeeScript string interpolation to append a leading "20" to `year` before it gets passed to the `Date` constructor, ensuring that this library supports year shorthand for at least the next 87 years :smile:
