### PR TITLE
Correct amex cvc validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Example:
 
 ``` javascript
 $.payment.validateCardCVC('123'); //=> true
-$.payment.validateCardCVC('123', 'amex'); //=> false
+$.payment.validateCardCVC('123', 'amex'); //=> true
 $.payment.validateCardCVC('1234', 'amex'); //=> true
 $.payment.validateCardCVC('12344'); //=> false
 ```

--- a/lib/jquery.payment.js
+++ b/lib/jquery.payment.js
@@ -74,7 +74,7 @@
       pattern: /^3[47]/,
       format: /(\d{1,4})(\d{1,6})?(\d{1,5})?/,
       length: [15],
-      cvcLength: [4],
+      cvcLength: [3, 4],
       luhn: true
     }, {
       type: 'visa',

--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -70,7 +70,7 @@ cards = [
       pattern: /^3[47]/
       format: /(\d{1,4})(\d{1,6})?(\d{1,5})?/
       length: [15]
-      cvcLength: [4]
+      cvcLength: [3..4]
       luhn: true
   }
   {

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -141,9 +141,9 @@ describe 'jquery.payment', ->
       topic = $.payment.validateCardCVC('123')
       assert.equal topic, true
 
-    it 'should not validate a three digit number with card type amex', ->
+    it 'should validate a three digit number with card type amex', ->
       topic = $.payment.validateCardCVC('123', 'amex')
-      assert.equal topic, false
+      assert.equal topic, true
 
     it 'should validate a three digit number with card type other than amex', ->
       topic = $.payment.validateCardCVC('123', 'visa')


### PR DESCRIPTION
### Correct amex cvc validation

I understand this could be an area of contention or debate, however:
- I did some research online and found that the 3 digit security code for AMEX is generally used only for internal support requests between a customer and AMEX, and I believe the predominant use-case of this library (developers who accept payments online) is best served with a three digit amex cvc being invalid. Take a look at [this forum discussion regarding the matter](http://creditcardforum.com/american-express/5148-amex-3-digit-security-code.html).
- The README states that three digit amex cvc's will be invalid as well, and they currently are not. 
- Feel free to do your own searching on the [American Express help website](https://search.americanexpress.com/app/answers/list/search/1/kw/).
- This pull request also incorporates some more automated tests which are just good for the library to have in general. 
- Everything that is advertised in the README is tested against, and now passes, and a couple additional tests were added as well. 
