### PR TITLE
Reformats card number when: 1) inserting digits, 2) backspacing in middle of string, 3) pasting snippets

### DIFF
--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -83,7 +83,7 @@ cards = [
   }
 ]
 
-maxLength = Math.max.apply(@, (Math.max.apply(@, card.length) for card in cards))
+maxLength = Math.max(Math.max(card.length...) for card in cards...)
 
 cardFromNumber = (num) ->
   num = (num + '').replace(/\D/g, '')


### PR DESCRIPTION
Hola!  We use your library at work and my coworkers pointed out that the credit card number formatting broke when they inserted new digits in the middle of their number, so I decided it was worth fixing.

**My PR fixes these Issues**
- Pasting in a snippet of a number e.g. "428888" does not format properly
- Inserting numbers in the middle of a string messes up the formatting
- Backspacing numbers in the middle of a string messes up the formatting
- Backspacing on a space removes the space, which messes up the formatting.

**Known Issues**
- We do not handle the Forward Delete
- The many edge cases when the user has text selected, then deletes or replaces it with new digits  (i.e. Issue #11 still exists.)
-  Fuc--forget IE 8 and below (for not supporting selectionStart.  Also in general.)  My fixes will not work in those browsers.

I'm fairly new to Javascript, so your feedback could be transformative.  Let me know how I can improve things in terms of style, efficiency, whether you are philosophically opposed to manipulating the user's cursor, etc.  Cheers!
