### PR TITLE
Missing discover for card types in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Returns a card type. Either:
 
 * `visa`
 * `mastercard`
+* `discover`
 * `amex`
 * `dinersclub`
 * `maestro`


### PR DESCRIPTION
`cardType` also returns `discover` but README fails to reflect that.
