### PR TITLE
Fix editing a filled-in CVC when text is selected

### DIFF
--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -294,6 +294,8 @@ restrictCVC = (e) ->
   digit   = String.fromCharCode(e.which)
   return unless /^\d+$/.test(digit)
 
+  return if hasTextSelected($target)
+
   val     = $target.val() + digit
   val.length <= 4
 


### PR DESCRIPTION
This fixes #54.
