### PR TITLE
Concordance between card expiration methods

### DIFF
--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -386,7 +386,7 @@ $.payment.validateCardExpiry = (month, year) =>
   year  = $.trim(year)
 
   return false unless /^\d+$/.test(month)
-  return false unless /^\d+$/.test(year)
+  return false unless /^\d{1,4}$/.test(year)
   return false unless parseInt(month, 10) <= 12
 
   if year.length is 2

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -106,6 +106,11 @@ describe 'jquery.payment', ->
       topic = $.payment.validateCardExpiry 13, currentTime.getFullYear()
       assert.equal topic, false
 
+    it 'that has an invalid year, bigger than 4 digits', ->
+      currentTime = new Date()
+      topic = $.payment.validateCardExpiry currentTime.getMonth() + 1, 20131
+      assert.equal topic, false
+
     it 'that is this year and month', ->
       currentTime = new Date()
       topic = $.payment.validateCardExpiry currentTime.getMonth() + 1, currentTime.getFullYear()
@@ -135,7 +140,7 @@ describe 'jquery.payment', ->
     it 'should fail if year or month is NaN', ->
       topic = $.payment.validateCardExpiry '12', NaN
       assert.equal topic, false
-    
+
     it 'should support year shorthand', ->
       assert.equal $.payment.validateCardExpiry('05', '20'), true
 


### PR DESCRIPTION
- Return false in case year has more than 4 digits in validateCardExpiry, to be in concordance with restrictExpiry method.
- Tests added for this case when year is greater than 4 digits using year exposed in the issue related.
