### PR TITLE
Autocomplete fixes for Chrome

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -50,7 +50,7 @@
 </head>
 <body>
 
-  <form novalidate autocomplete="on">
+  <form novalidate autocomplete="on" method="POST">
     <h2>Card number formatting</h2>
 
     <input type="text" class="cc-number" pattern="\d*" autocomplete="cc-number" placeholder="Card number" required>


### PR DESCRIPTION
Adds `method="POST"` so autocomplete would work on Chrome with the example, per [this Stack Overflow answer and Chrome bug report](http://stackoverflow.com/questions/8715000/enabling-browsers-form-auto-filling).

Also changes `x-autocompletetype` to `autocomplete` per #66.
