### PR TITLE
Cards globally accessible

### DIFF
--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -8,7 +8,7 @@ $.fn.payment = (method, args...) ->
 
 defaultFormat = /(\d{1,4})/g
 
-cards = [
+$.payment.cards = cards = [
   {
       type: 'maestro'
       pattern: /^(5018|5020|5038|6304|6759|676[1-3])/


### PR DESCRIPTION
The Credit Card objects could be accesible outside the plugin scope in order to extend them if needed, to retrieve the Card object and perform custom actions, etc.

I have not thought about all implications about this change, but opened this pull request to discuss it :-)