### PR TITLE
Restrict visa valid digit lengths to 13/16

### DIFF
--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -77,7 +77,7 @@ cards = [
       type: 'visa'
       pattern: /^4/
       format: defaultFormat
-      length: [13..16]
+      length: [13, 16]
       cvcLength: [3]
       luhn: true
   }


### PR DESCRIPTION
As per http://en.wikipedia.org/wiki/Bank_card_number#Issuer_identification_number_.28IIN.29 visa numbers are only 13/16 digits long. This prevents numbers like `4111 1111 1111 22` from incorrectly passing `validateCardNumber`
