### PR TITLE
Update jquery.payment.js

### DIFF
--- a/lib/jquery.payment.js
+++ b/lib/jquery.payment.js
@@ -283,6 +283,9 @@
     if (e.which < 33) {
       return true;
     }
+    if (e.which === 118 && e.ctrlKey || e.which === 86 && e.ctrlKey) {
+      return true;
+    }
     input = String.fromCharCode(e.which);
     return !!/[\d\s]/.test(input);
   };


### PR DESCRIPTION
In firefox it is not possible to paste (ctrl+v) values into fields so we should permit key combinations
