### PR TITLE
Use a protocol-relative jQuery URL in the example

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
   <script src="../lib/jquery.payment.js"></script>
 
   <style type="text/css" media="screen">


### PR DESCRIPTION
Fixes viewing the example on a HTTPS URL, such as https://stripe.github.io/jquery.payment/example/
