### PR TITLE
Add jsdom to fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "0.10"

--- a/Cakefile
+++ b/Cakefile
@@ -18,7 +18,7 @@ task 'watch', 'Watch src/ for changes', ->
     print data.toString()
 
 task 'test', 'Run tests', ->
-  mocha = spawn 'mocha', ['--compilers', 'coffee:coffee-script']
+  mocha = spawn 'mocha', ['--compilers', 'coffee:coffee-script/register']
   mocha.stderr.on 'data', (data) ->
     process.stderr.write data.toString()
   mocha.stdout.on 'data', (data) ->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jQuery.payment
+# jQuery.payment [![Build Status](https://travis-ci.org/stripe/jquery.payment.svg?branch=master)](https://travis-ci.org/stripe/jquery.payment)
 
 A general purpose library for building credit card forms, validating inputs and formatting numbers.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "cake test"
   },
   "repository": {
     "type": "git",
@@ -23,5 +23,11 @@
   "license": "MIT",
   "dependencies": {
     "jquery": "latest"
+  },
+  "devDependencies": {
+    "jsdom": "*",
+    "cake": "*",
+    "coffee-script": "*",
+    "mocha": "*"
   }
 }

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -1,4 +1,7 @@
 assert = require('assert')
+jsdom = require('jsdom').jsdom
+doc = jsdom('')
+global.window = doc.createWindow()
 $      = require('jquery')
 global.jQuery = $
 


### PR DESCRIPTION
Add development dependencies needed to execute the tests. Add `npm test`
support using Cake. Also add Travis support (and corresponding build badge)

This PR fixes #84 and #49.
