### PR TITLE
README fix to add jcb as a possible return value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Returns a card type. Either:
 * `mastercard`
 * `discover`
 * `amex`
+* `jcb`
 * `dinersclub`
 * `maestro`
 * `laser`


### PR DESCRIPTION
In the README.md, there's a list of possible return values. The value `jcb` was omitted and this PR simply adds that to the README.
