### PR TITLE
[Bugfix] Android 4.2.2 doesn't listen to key events

### DIFF
--- a/lib/jquery.payment.js
+++ b/lib/jquery.payment.js
@@ -368,11 +368,11 @@
 
   $.payment.fn.formatCardExpiry = function() {
     this.payment('restrictNumeric');
-    this.on('keypress', restrictExpiry);
-    this.on('keypress', formatExpiry);
-    this.on('keypress', formatForwardSlash);
-    this.on('keypress', formatForwardExpiry);
-    this.on('keydown', formatBackExpiry);
+    this.on('keypress input', restrictExpiry);
+    this.on('keypress input', formatExpiry);
+    this.on('keypress input', formatForwardSlash);
+    this.on('keypress input', formatForwardExpiry);
+    this.on('keydown input', formatBackExpiry);
     return this;
   };
 

--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -325,11 +325,11 @@ $.payment.fn.formatCardCVC = ->
 
 $.payment.fn.formatCardExpiry = ->
   @payment('restrictNumeric')
-  @on('keypress', restrictExpiry)
-  @on('keypress', formatExpiry)
-  @on('keypress', formatForwardSlash)
-  @on('keypress', formatForwardExpiry)
-  @on('keydown',  formatBackExpiry)
+  @on('keypress input', restrictExpiry)
+  @on('keypress input', formatExpiry)
+  @on('keypress input', formatForwardSlash)
+  @on('keypress input', formatForwardExpiry)
+  @on('keydown input',  formatBackExpiry)
   this
 
 $.payment.fn.formatCardNumber = ->

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -266,3 +266,12 @@ describe 'jquery.payment', ->
       $expiry.trigger(e)
 
       assert.equal $expiry.val(), '1'
+
+    it 'should work with "input" event', ->
+      $expiry = $('<input type=text>').payment('formatCardExpiry')
+
+      e = $.Event('input');
+      e.which = 52 # '4'
+      $expiry.trigger(e)
+
+      assert.equal $expiry.val(), '04 / '


### PR DESCRIPTION
This fixes a bug where Android 4.4.2 doesn't send key related events.
