### PR TITLE
[Bugfix] Add forbrugsforeningen and dankort credit cards

### DIFF
--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -92,6 +92,22 @@ cards = [
       cvcLength: [3]
       luhn: true
   }
+  {
+      type: 'forbrugsforeningen'
+      pattern: /^600722/
+      format: defaultFormat
+      length: [16]
+      cvcLength: [3]
+      luhn: true
+  }
+  {
+      type: 'dankort'
+      pattern: /^5019/
+      format: defaultFormat
+      length: [16]
+      cvcLength: [3]
+      luhn: true
+  }
 ]
 
 cardFromNumber = (num) ->

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -82,6 +82,12 @@ describe 'jquery.payment', ->
       assert($.payment.validateCardNumber('3530111333300000'), 'jcb')
       assert($.payment.validateCardNumber('3566002020360505'), 'jcb')
 
+      assert($.payment.validateCardNumber('6007220000000000'), 'forbrugsforeningen')
+      assert($.payment.validateCardNumber('6007221111111111'), 'forbrugsforeningen')
+
+      assert($.payment.validateCardNumber('5019000000000000'), 'dankort')
+      assert($.payment.validateCardNumber('5019111111111111'), 'dankort')
+
   describe 'Validating a CVC', ->
     it 'should fail if is empty', ->
       topic = $.payment.validateCardCVC ''


### PR DESCRIPTION
This adds support for both forbrugsforeningen and dankort credit cards, heavily used in their specific countries.
