### PR TITLE
validate cvc for amex accepts 3 digit cvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Example:
 
 ``` javascript
 $.payment.validateCardCVC('123'); //=> true
-$.payment.validateCardCVC('123', 'amex'); //=> true
+$.payment.validateCardCVC('123', 'amex'); //=> no
 $.payment.validateCardCVC('1234', 'amex'); //=> true
 $.payment.validateCardCVC('12344'); //=> false
 ```

--- a/lib/jquery.payment.js
+++ b/lib/jquery.payment.js
@@ -66,7 +66,7 @@
       pattern: /^3[47]/,
       format: /(\d{1,4})(\d{1,6})?(\d{1,5})?/,
       length: [15],
-      cvcLength: [3, 4],
+      cvcLength: [4],
       luhn: true
     }, {
       type: 'dinersclub',

--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -65,7 +65,7 @@ cards = [
       pattern: /^3[47]/
       format: /(\d{1,4})(\d{1,6})?(\d{1,5})?/
       length: [15]
-      cvcLength: [3..4]
+      cvcLength: [4]
       luhn: true
   }
   {

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -168,9 +168,9 @@ describe 'jquery.payment', ->
       topic = $.payment.validateCardCVC('123')
       assert.equal topic, true
 
-    it 'should validate a three digit number with card type amex', ->
+    it 'should not validate a three digit number with card type amex', ->
       topic = $.payment.validateCardCVC('123', 'amex')
-      assert.equal topic, true
+      assert.equal topic, false
 
     it 'should validate a three digit number with card type other than amex', ->
       topic = $.payment.validateCardCVC('123', 'visa')


### PR DESCRIPTION
```
console.log($.payment.validateCardCVC('123'));
console.log($.payment.validateCardCVC('123','amex'));
console.log($.payment.validateCardCVC('1234','amex'))
```

---

true
true
true
