### PR TITLE
fix test that fails in November

### DIFF
--- a/test/index.coffee
+++ b/test/index.coffee
@@ -149,7 +149,7 @@ describe 'jquery.payment', ->
     it 'that has string numbers', ->
       currentTime = new Date()
       currentTime.setFullYear(currentTime.getFullYear() + 1, currentTime.getMonth() + 2)
-      topic = $.payment.validateCardExpiry currentTime.getMonth() + '', currentTime.getFullYear() + ''
+      topic = $.payment.validateCardExpiry currentTime.getMonth() + 1 + '', currentTime.getFullYear() + ''
       assert.equal topic, true
 
     it 'that has non-numbers', ->


### PR DESCRIPTION
This test fails in November because after setting `currentTime.setFullYear(currentTime.getFullYear() + 1, currentTime.getMonth() + 2)`, `currentTime.getMonth()` returns 0. The fix adds 1 to the month to ensure it returns a valid month.
