### PR TITLE
Recommending type="tel" instead of pattern="\d*"

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,17 +198,17 @@ We recommend you turn autocomplete on for credit card forms, except for the CVC 
 You should also mark up your fields using the [Autocomplete Types spec](http://wiki.whatwg.org/wiki/Autocomplete_Types). These are respected by a number of browsers, including Chrome.
 
 ``` html
-<input type="text" class="cc-number" pattern="\d*" autocomplete="cc-number" placeholder="Card number" required>
+<input type="tel" class="cc-number" pattern="\d*" autocomplete="cc-number" placeholder="Card number" required>
 ```
 
 Set `autocomplete` to `cc-number` for credit card numbers and `cc-exp` for credit card expiry.
 
 ## Mobile recommendations
 
-We recommend you set the `pattern` attribute which will cause the numeric keyboard to be displayed on mobiles:
+We recommend you to use `<input type="tel">` which will cause the numeric keyboard to be displayed on mobiles:
 
 ``` html
-<input class="cc-number" pattern="\d*">
+<input type="tel" class="cc-number">
 ```
 
-You may have to turn off HTML5 validation (using the `novalidate` form attribute) when using this `pattern`, as it won't match space formatting.
+You may have to turn off HTML5 validation (using the `novalidate` form attribute) when using this `type`, as it won't match space formatting.


### PR DESCRIPTION
The `pattern="\d*"` recommendation didn't make the numeric keyboard appear on any device I tested, so I took a look to the [Stripe Checkout demo](https://checkout.stripe.com/v3) code and saw that they were using `type="tel"` to make the it appear.

I guess that's a better recommendation, isn't it?