### PR TITLE
RTL Support

### DIFF
--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -180,12 +180,12 @@ formatCardNumber = (e) ->
   # If '4242' + 4
   if re.test(value)
     e.preventDefault()
-    setTimeout -> $target.val(value + ' ' + digit)
+    setTimeout -> $target.val(value + '\u00A0' + digit)
 
   # If '424' + 2
   else if re.test(value + digit)
     e.preventDefault()
-    setTimeout -> $target.val(value + digit + ' ')
+    setTimeout -> $target.val(value + digit + '\u00A0')
 
 formatBackCardNumber = (e) ->
   $target = $(e.currentTarget)
@@ -244,7 +244,7 @@ formatForwardExpiry = (e) ->
 
 formatForwardSlashAndSpace = (e) ->
   which = String.fromCharCode(e.which)
-  return unless which is '/' or which is ' '
+  return unless which is '/' or which is '\u00A0'
 
   $target = $(e.currentTarget)
   val     = $target.val()
@@ -345,7 +345,7 @@ setCardType = (e) ->
     allTypes = (card.type for card in cards)
 
     $target.removeClass('unknown')
-    $target.removeClass(allTypes.join(' '))
+    $target.removeClass(allTypes.join('\u00A0'))
 
     $target.addClass(cardType)
     $target.toggleClass('identified', cardType isnt 'unknown')
@@ -485,13 +485,13 @@ $.payment.formatCardNumber = (num) ->
   num = num[0...upperLength]
 
   if card.format.global
-    num.match(card.format)?.join(' ')
+    num.match(card.format)?.join('\u00A0')
   else
     groups = card.format.exec(num)
     return unless groups?
     groups.shift()
     groups = $.grep(groups, (n) -> n) # Filter empty groups
-    groups.join(' ')
+    groups.join('\u00A0')
 
 $.payment.formatExpiry = (expiry) ->
   parts = expiry.match(/^\D*(\d{1,2})(\D+)?(\d{1,4})?/)


### PR DESCRIPTION
Currently, if you sets ```<html dir="rtl"> ``` the browser flip the CC number like 4 words instead 1 whole block
![screenshot-localhost 63342 2015-01-22 00-07-25](https://cloud.githubusercontent.com/assets/3717858/5849893/a910de06-a1ca-11e4-8267-3d5523d357c7.png)

(Sorry for my poor English)