### PR TITLE
Update README to suggest better input attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ Set `autocomplete` to `cc-number` for credit card numbers and `cc-exp` for credi
 
 ## Mobile recommendations
 
-We recommend you to use `<input type="tel">` which will cause the numeric keyboard to be displayed on mobile devices:
+We recommend you to use `<input type="text" pattern="[0-9]*">` which will cause the numeric keyboard to be displayed on mobile devices:
 
 ``` html
-<input type="tel" class="cc-number">
+<input type="text" pattern="[0-9]*" class="cc-number">
 ```


### PR DESCRIPTION
This accomplishes the same thing (showing number input only), and is more semantic than setting the type to `tel`.

There don't appear to be any browser support issues.
https://developer.mozilla.org/en/docs/Web/HTML/Element/Input