### PR TITLE
Fix #158: Change MasterCard range to 51-55

### DIFF
--- a/lib/jquery.payment.js
+++ b/lib/jquery.payment.js
@@ -56,7 +56,7 @@
       luhn: true
     }, {
       type: 'mastercard',
-      pattern: /^(5[0-5]|2[2-7])/,
+      pattern: /^(5[1-5]|2[2-7])/,
       format: defaultFormat,
       length: [16],
       cvcLength: [3],

--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -54,7 +54,7 @@ $.payment.cards = cards = [
   }
   {
     type: 'mastercard'
-    pattern: /^(5[0-5]|2[2-7])/
+    pattern: /^(5[1-5]|2[2-7])/
     format: defaultFormat
     length: [16]
     cvcLength: [3]


### PR DESCRIPTION
References (found them in #158):

* Mastercard range is listed as 51-55 - http://en.wikipedia.org/wiki/Bank_card_number
* http://www.barclaycard.co.uk/business/files/Ranges_and_Rules_September_2014.pdf