### PR TITLE
Replace `char` with `chr` to avoid reserved word

### DIFF
--- a/lib/jquery.payment.js
+++ b/lib/jquery.payment.js
@@ -172,7 +172,7 @@
   };
 
   replaceFullWidthChars = function(str) {
-    var char, chars, fullWidth, halfWidth, idx, value, _i, _len;
+    var chars, chr, fullWidth, halfWidth, idx, value, _i, _len;
     if (str == null) {
       str = '';
     }
@@ -181,12 +181,12 @@
     value = '';
     chars = str.split('');
     for (_i = 0, _len = chars.length; _i < _len; _i++) {
-      char = chars[_i];
-      idx = fullWidth.indexOf(char);
+      chr = chars[_i];
+      idx = fullWidth.indexOf(chr);
       if (idx > -1) {
-        char = halfWidth[idx];
+        chr = halfWidth[idx];
       }
-      value += char;
+      value += chr;
     }
     return value;
   };

--- a/src/jquery.payment.coffee
+++ b/src/jquery.payment.coffee
@@ -159,10 +159,11 @@ replaceFullWidthChars = (str = '') ->
   value = ''
   chars = str.split('')
 
-  for char in chars
-    idx = fullWidth.indexOf(char)
-    char = halfWidth[idx] if idx > -1
-    value += char
+  # Avoid using reserved word `char`
+  for chr in chars
+    idx = fullWidth.indexOf(chr)
+    chr = halfWidth[idx] if idx > -1
+    value += chr
 
   value
 


### PR DESCRIPTION
Fixes #175 by replacing `char` in for loop with `chr`, which avoids generated a reserved word variable name.