### PR TITLE
Updated jQuery dependency

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.1/jquery.min.js"></script>
   <script src="../lib/jquery.payment.js"></script>
 
   <style type="text/css" media="screen">

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "cake test"
   },
   "dependencies": {
-    "jquery": ">=1.5"
+    "jquery": ">=1.7"
   },
   "devDependencies": {
     "cake": "~0.1",

--- a/payment.jquery.json
+++ b/payment.jquery.json
@@ -24,6 +24,6 @@
   "bugs": "https://github.com/stripe/jquery.payment/issues",
   "demo": "http://stripe.github.io/jquery.payment/example",
   "dependencies": {
-    "jquery": ">=1.5"
+    "jquery": ">=1.7"
   }
 }


### PR DESCRIPTION
The `package.json` and `payment.jquery.json` files had `>=1.5` for the `jquery` dependency.

However, the code uses `.prop()` which was added in 1.6 and `.on()` which was added in 1.7, so the minimum required version is actually 1.7. This PR fixes that.

r? @jenanwise 
