### PR TITLE
uatp card defination added

### DIFF
--- a/lib/jquery.payment.js
+++ b/lib/jquery.payment.js
@@ -103,6 +103,13 @@
       length: [16],
       cvcLength: [3],
       luhn: true
+    }, {
+      type: 'uatp',
+      patterns: [1],
+      format: /(\d{1,4})(\d{1,5})?(\d{1,6})?/,
+      length: [15],
+      cvcLength: [3, 4],
+      luhn: true
     }
   ];
 


### PR DESCRIPTION
## Summary

UATP card defination added to card list

## Motivation

UATP is the low cost payment network privately owned by the world's airlines. UATP card does not need luhn check and ist format is 4-5-6 
for more details : http://www.uatp.com/products/Charge-Cards.html

## Testing

With sample UATP card (135412345678911). with this change card formatted successfully
