### PR TITLE
Updated README.md autocomplete section

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,22 +226,17 @@ Run `cake test`
 
 ## Autocomplete recommendations
 
-We recommend you turn autocomplete on for credit card forms, except for the CVC field (which should never be stored). You can do this by setting the `autocomplete` attribute:
+We recommend you turn autocomplete on for credit card forms, *except for the CVC field (which should never be stored)*. You can do this by setting the `autocomplete` attribute:
 
 ``` html
 <form autocomplete="on">
-  <input class="cc-number">
+  <input class="cc-number" autocomplete="cc-number">
+  <input class="cc-exp" autocomplete="cc-exp">
   <input class="cc-cvc" autocomplete="off">
 </form>
 ```
 
-You should also mark up your fields using the [Autofill spec](https://html.spec.whatwg.org/multipage/forms.html#autofill). These are respected by a number of browsers, including Chrome.
-
-``` html
-<input type="tel" class="cc-number" autocomplete="cc-number">
-```
-
-Set `autocomplete` to `cc-number` for credit card numbers and `cc-exp` for credit card expiry.
+You should mark up your fields using the [Autofill spec](https://html.spec.whatwg.org/multipage/forms.html#autofill). These are respected by a number of browsers, including Chrome, Safari, Firefox.
 
 ## Mobile recommendations
 


### PR DESCRIPTION
## Summary

Updated README.md autocomplete section. Example autocomplete attributes for most commonly used fields.

## Motivation

I found the documentation confusing when reading this section, as you need to carefully read the paragraph above the code snippet, otherwise, you may read it as 'don't use autocomplete'

## Testing

Verified using spell check.

