### PR TITLE
Fully deprecate jquery.payment.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,16 +1,1 @@
-Thanks for your interest in contributing!
-
-## Filing issues
-
-`jQuery.payment` is not currently accepting feature requests. We _are_ interested in fixing bugs and updating credit card BINs where appropriate. Please file issues for these items only.
-
-When filing bugs, make sure to follow the issue template. When reporting credit card BIN changes, please include links to supporting documentation.
-
-## Submitting pull requests
-
-We will happily review and merge pull requests for bugs and card number changes. When submitting a pull request:
-
-- Ensure that the code and commit message are well-commented and grammatically correct.
-- Follow the style of the rest of the code, where possible.
-- Make sure that your diff is the minimal set of changes necessary to fix the bug in question.
-- Follow the pull request template.
+Thanks for your interest in contributing! jquery.payment is deprecated. Please see "Project Status" in the README.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,13 +1,1 @@
-<!-- NOTE: Please do not use issues for feature requests. Please read the README and contributing guidelines before filing issues -->
-
-## Expected behavior
-
-Describe the expected behavior. For new credit card BIN numbers, please include supporting references.
-
-## Actual behavior
-
-Describe the actual behavior. List all browsers affected, as specifically as possible (e.g. "Chrome 49.2623.112 on OS X 10.11.4", not just "Chrome").
-
-## Steps to reproduce
-
-Describe steps to reproduce the problem. Please include a link to a minimal reproduction of the problem with jsfiddle (or similar tool) where possible.
+<!-- Thanks for your interest in contributing! jquery.payment is deprecated. Please see "Project Status" in the README. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,1 @@
-## Summary
-
-Simple summary of what was changed.
-
-## Motivation
-
-Why are you making this change? Please provide supporting references for new BIN numbers and links to minimal reproductions (e.g. with jsfiddle) when fixing bugs.
-
-## Testing
-
-How was the code tested? Be as specific as possible.
+<!-- Thanks for your interest in contributing! jquery.payment is deprecated. Please see "Project Status" in the README. -->

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ A general purpose library for building credit card forms, validating inputs and 
 
 ## Project status
 
-We consider `jQuery.payment` to be feature complete. We continue to use it in production, and we will happily accept bug reports and pull requests fixing those bugs, but we will not be adding new features or modifying the project for new frameworks or build systems.
+**jquery.payment is deprecated. We recommend that you use either [Stripe Checkout](https://stripe.com/docs/checkout) or [Stripe Elements](https://stripe.com/docs/elements) to collect card information.**
 
-### Why?
-
-The library was born in a different age, and we think it has served tremendously, but it is fundamentally doing too many things. Complecting DOM element manipulation, input masking, card formatting, and cursor positioning makes it difficult to test and modify. An ideal version of this library would separate the independent components and make the internal logic functional.
+We will patch jquery.payment for major critical/security issues, but we won't be adding new features.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Fully deprecate jquery.payment.

## Motivation

Users should use Stripe Checkout or Stripe Elements now instead.